### PR TITLE
Just a check if mikrotik version is above 7 to disable accounting

### DIFF
--- a/custom_components/mikrotik_router/mikrotik_controller.py
+++ b/custom_components/mikrotik_router/mikrotik_controller.py
@@ -655,7 +655,11 @@ class MikrotikControllerData:
                 {"name": "routerboard", "type": "bool"},
                 {"name": "model", "default": "unknown"},
                 {"name": "serial-number", "default": "unknown"},
-                {"name": "firmware", "source": "current-firmware", "default": "unknown"},
+                {
+                    "name": "firmware",
+                    "source": "current-firmware",
+                    "default": "unknown",
+                },
             ],
         )
 


### PR DESCRIPTION
## Proposed change
Just a check if mikrotik version is above 7 to disable accounting. Also fixes firmware info because mikrotik is returning current firmware version in field 'current-firmware'. In latest code this was always filled as 'unknown'.


## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Checklist
- [x] The code change is tested and works locally.
- [ ] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
