### PR TITLE
Adding support for overriding zone name in device_tracker

### DIFF
--- a/custom_components/mikrotik_router/config_flow.py
+++ b/custom_components/mikrotik_router/config_flow.py
@@ -16,6 +16,8 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_PASSWORD,
     CONF_SSL,
+    CONF_ZONE,
+    STATE_HOME
 )
 from homeassistant.core import callback
 
@@ -207,6 +209,13 @@ class MikrotikControllerOptionsFlowHandler(OptionsFlow):
                             CONF_TRACK_HOSTS_TIMEOUT, DEFAULT_TRACK_HOST_TIMEOUT
                         ),
                     ): int,
+                    vol.Optional(
+                        CONF_ZONE,
+                        default=self.config_entry.options.get(
+                            CONF_ZONE, STATE_HOME
+                        ),
+                    ): str,
+
                 }
             ),
         )

--- a/custom_components/mikrotik_router/device_tracker.py
+++ b/custom_components/mikrotik_router/device_tracker.py
@@ -9,6 +9,7 @@ from homeassistant.components.device_tracker.const import SOURCE_TYPE_ROUTER
 from homeassistant.const import (
     CONF_NAME,
     ATTR_ATTRIBUTION,
+    STATE_NOT_HOME,
 )
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
@@ -299,6 +300,13 @@ class MikrotikControllerHostDeviceTracker(MikrotikControllerDeviceTracker):
         ):
             return "mdi:lan-connect"
         return "mdi:lan-disconnect"
+
+    @property
+    def state(self) -> str:
+        """Return the state of the device."""
+        if self.is_connected:
+            return self._ctrl.option_zone
+        return STATE_NOT_HOME
 
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:

--- a/custom_components/mikrotik_router/mikrotik_controller.py
+++ b/custom_components/mikrotik_router/mikrotik_controller.py
@@ -24,6 +24,8 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_PASSWORD,
     CONF_SSL,
+    CONF_ZONE,
+    STATE_HOME,
 )
 
 from .const import (
@@ -310,6 +312,17 @@ class MikrotikControllerData:
         return self.config_entry.options.get(
             CONF_UNIT_OF_MEASUREMENT, DEFAULT_UNIT_OF_MEASUREMENT
         )
+
+    # ---------------------------
+    #   option_zone
+    # ---------------------------
+    @property
+    def option_zone(self):
+        """Config entry option to not track ARP."""
+        return self.config_entry.options.get(
+            CONF_ZONE, STATE_HOME
+        )
+    
 
     # ---------------------------
     #   signal_update

--- a/custom_components/mikrotik_router/strings.json
+++ b/custom_components/mikrotik_router/strings.json
@@ -29,7 +29,8 @@
                     "scan_interval": "Scan interval (requires HA restart)",
                     "track_iface_clients": "Show client MAC and IP on interfaces",
                     "unit_of_measurement": "Unit of measurement",
-                    "track_network_hosts_timeout": "Track network devices timeout (seconds)"
+                    "track_network_hosts_timeout": "Track network devices timeout (seconds)",
+                    "zone": "Zone for device tracker"
                 },
                 "title": "Basic options"
             },


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here. If it fixes a bug
  or resolves a feature request, be sure to link to that issue.
-->
I have MikroTik routers at two different locations and each location has its own zone in home-assistant. Adding the zone name as an option for each MikroTik integration enables us to have full automatic presence detection across multiple zones.

## Type of change
<!--
  What type of change does your PR introduces?
-->
- [ ] Bugfix
- [x] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Add any other context about your PR here.
-->
Default zone is still `home`

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [x] The code change is tested and works locally.
- [ ] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
