### PR TITLE
Added logging of the Filter ID

### DIFF
--- a/custom_components/mikrotik_router/mikrotik_controller.py
+++ b/custom_components/mikrotik_router/mikrotik_controller.py
@@ -1171,9 +1171,10 @@ class MikrotikControllerData:
             if self.data["filter"][uid]["uniq-id"] not in self.filter_removed:
                 self.filter_removed[self.data["filter"][uid]["uniq-id"]] = 1
                 _LOGGER.error(
-                    "Mikrotik %s duplicate Filter rule %s, entity will be unavailable.",
+                    "Mikrotik %s duplicate Filter rule %s (ID %s), entity will be unavailable.",
                     self.host,
                     self.data["filter"][uid]["name"],
+                    self.data["filter"][uid][".id"],
                 )
 
             del self.data["filter"][uid]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here. If it fixes a bug
  or resolves a feature request, be sure to link to that issue.
-->

When having a lot of filter rules, the auto-generated names of the filter rules aren't easy to find in the Winbox UI.
The follow log was displayed:
> Mikrotik x.x.x.x duplicate Filter rule accept,any:any, entity will be unavailable.
> Mikrotik x.x.x.x duplicate Filter rule drop,any:any, entity will be unavailable.

I had to download the API JSON to find out the name was exactly that ("accept;any:any"). I thought it would be helpful if the (duplicate) ID would be logged as well.


## Type of change
<!--
  What type of change does your PR introduces?
-->
- [ ] Bugfix
- [ ] New feature
- [x] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Add any other context about your PR here.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [x] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [x] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.
