### PR TITLE
Support for additional attributes on execute

### DIFF
--- a/custom_components/mikrotik_router/mikrotik_controller.py
+++ b/custom_components/mikrotik_router/mikrotik_controller.py
@@ -387,9 +387,9 @@ class MikrotikControllerData:
     # ---------------------------
     #   execute
     # ---------------------------
-    def execute(self, path, command, param, value):
+    def execute(self, path, command, param, value, attributes=None):
         """Change value using Mikrotik API"""
-        return self.api.execute(path, command, param, value)
+        return self.api.execute(path, command, param, value, attributes)
 
     # ---------------------------
     #   run_script
@@ -1544,7 +1544,7 @@ class MikrotikControllerData:
         ):
             return
 
-        self.execute("/system/package/update", "check-for-updates", None, None)
+        self.execute("/system/package/update", "check-for-updates", None, None, {"duration": 10})
         self.data["fw-update"] = parse_api(
             data=self.data["fw-update"],
             source=self.api.query("/system/package/update"),

--- a/custom_components/mikrotik_router/mikrotik_controller.py
+++ b/custom_components/mikrotik_router/mikrotik_controller.py
@@ -1544,7 +1544,9 @@ class MikrotikControllerData:
         ):
             return
 
-        self.execute("/system/package/update", "check-for-updates", None, None, {"duration": 10})
+        self.execute(
+            "/system/package/update", "check-for-updates", None, None, {"duration": 10}
+        )
         self.data["fw-update"] = parse_api(
             data=self.data["fw-update"],
             source=self.api.query("/system/package/update"),

--- a/custom_components/mikrotik_router/mikrotikapi.py
+++ b/custom_components/mikrotik_router/mikrotikapi.py
@@ -258,7 +258,7 @@ class MikrotikAPI:
     # ---------------------------
     #   execute
     # ---------------------------
-    def execute(self, path, command, param, value) -> bool:
+    def execute(self, path, command, param, value, attributes=None) -> bool:
         """Execute a command"""
         entry_found = None
         params = {}
@@ -291,6 +291,9 @@ class MikrotikAPI:
                 return True
 
             params = {".id": entry_found}
+
+        if attributes:
+            params.update(attributes)
 
         self.lock.acquire()
         try:


### PR DESCRIPTION
## Proposed change
Linking the issue #284 . 
Problem with RouterOS check-for-updates method which hangs on unexpected response.

Execute method is extended with attributes=None params. In check-for-updates call there is a hardcoded 10 second duration value, we can set it to some other dynamic value if you wish, but from my testing if this call didn't finish in 10 seconds, it wont finish ever.


## Type of change
- [X] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Checklist
- [X] The code change is tested and works locally.
- [X] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
