### PR TITLE
Add wifi support for ROS 7.13+ devices without a physical wifi radio

### DIFF
--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -532,6 +532,10 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                 self.support_capsman = False
                 self._wifimodule = "wifi"
                 
+            elif self.minor_fw_version >= 13:
+                self.support_capsman = False
+                self._wifimodule = "wifi"
+                
             else:
                 self.support_capsman = True
                 self.support_wireless = bool(self.minor_fw_version < 13)

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -532,7 +532,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                 self.support_capsman = False
                 self._wifimodule = "wifi"
                 
-            elif self.minor_fw_version >= 13:
+            elif (self.major_fw_version == 7 and self.minor_fw_version >= 13) or self.major_fw_version > 7:
                 self.support_capsman = False
                 self._wifimodule = "wifi"
                 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here. If it fixes a bug
  or resolves a feature request, be sure to link to that issue.
-->
My CCR2004 has no physical wifi radio, but can manage CAPs through the `wifi` menu.
Since ROS 7.13, this is no longer a separate package (only `routeros` is listed under packages).
With this PR, we add support for this scenario by disabling capsman and setting the `_wifimodule` to `wifi` if we're running on ROS 7.13 or later.

## Type of change
<!--
  What type of change does your PR introduces?
-->
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
<!--
  Add any other context about your PR here.
-->
Note: The code was not formatted with `black` as that would have resulted in a lot of unrelated changes.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [x] The code change is tested and works locally.
- [ ] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
