### PR TITLE
Add mangle uniq

### DIFF
--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -1066,6 +1066,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                 {"name": "dst-port", "default": "any"},
                 {"name": "src-address-list", "default": "any"},
                 {"name": "dst-address-list", "default": "any"},
+                {"name": "commnet", "default": "none"},
                 {
                     "name": "enabled",
                     "source": "disabled",
@@ -1094,6 +1095,8 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                     {"key": "src-address-list"},
                     {"text": "-"},
                     {"key": "dst-address-list"},
+                    {"text": ","},
+                    {"key": "comment"},
                 ],
                 [
                     {"name": "name"},

--- a/custom_components/mikrotik_router/switch.py
+++ b/custom_components/mikrotik_router/switch.py
@@ -249,7 +249,8 @@ class MikrotikMangleSwitch(MikrotikSwitch):
                 f"{self._data['chain']},{self._data['action']},{self._data['protocol']},"
                 f"{self._data['src-address']}:{self._data['src-port']}-"
                 f"{self._data['dst-address']}:{self._data['dst-port']},"
-                f"{self._data['src-address-list']}-{self._data['dst-address-list']}"
+                f"{self._data['src-address-list']}-{self._data['dst-address-list']},"
+                f"{self._data['comment']}"
             ):
                 value = self.coordinator.data["mangle"][uid][".id"]
 

--- a/custom_components/mikrotik_router/switch.py
+++ b/custom_components/mikrotik_router/switch.py
@@ -271,7 +271,8 @@ class MikrotikMangleSwitch(MikrotikSwitch):
                 f"{self._data['chain']},{self._data['action']},{self._data['protocol']},"
                 f"{self._data['src-address']}:{self._data['src-port']}-"
                 f"{self._data['dst-address']}:{self._data['dst-port']},"
-                f"{self._data['src-address-list']}-{self._data['dst-address-list']}"
+                f"{self._data['src-address-list']}-{self._data['dst-address-list']},"
+                f"{self._data['comment']}"
             ):
                 value = self.coordinator.data["mangle"][uid][".id"]
 


### PR DESCRIPTION
## Proposed change

Add support for using mangle rule 'comment' field as part of the unique identifier for switches in Home Assistant.

### Motivation
i managing multiple mangle rules for VPN traffic routing, the existing unique identifier keys may not be sufficient to distinguish between similar rules. Adding the 'comment' field allows for better identification and management of mangle rules through Home Assistant, especially when dealing with multiple rules that share common properties.

I previously skipped rules with empty comments, but you brought them back. I think having these rules makes the system more organized and easier to manage, especially when wanting to control rules through Home Assistant

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information


## Checklist

- [x] The code change is tested and works locally.
- [ ] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
