### PR TITLE
mikrotikapi.py: Add SSL cert verification

### DIFF
--- a/custom_components/mikrotik_router/mikrotikapi.py
+++ b/custom_components/mikrotik_router/mikrotikapi.py
@@ -122,7 +122,9 @@ class MikrotikAPI:
             if self._ssl_wrapper is None:
                 ssl_context = ssl.create_default_context()
                 ssl_context.check_hostname = False
-                ssl_context.verify_mode = ssl.CERT_NONE
+                # Disable strict checking
+                ssl_context.verify_flags &= ~ssl.VERIFY_X509_STRICT
+                ssl_context.verify_mode = ssl.CERT_REQUIRED
                 self._ssl_wrapper = ssl_context.wrap_socket
             kwargs["ssl_wrapper"] = self._ssl_wrapper
         self.lock.acquire()


### PR DESCRIPTION
## Proposed change
This only adds the minimal ssl cert verification, disabling the hostname check which I think is not so useful anwyays on internal routers/switches which commonly will not have externally routable hostnames and disables the strict checking to allow easier use of self made CAs without intermediate CAs restricting key usage etc...

## Type of change
- [x] Bugfix
- [x] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

One could argue not verifying SSL certs is a bug but I guess this was done on purpose and I didn't hide it behind a config flag...

## Additional information
<!--
  Add any other context about your PR here.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [x] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
