### PR TITLE
Reverse direction of Kidcontrol Paused switch

### DIFF
--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -1289,7 +1289,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                 {"name": "sun", "default": "None"},
                 {"name": "comment"},
                 {"name": "blocked", "type": "bool", "default": False},
-                {"name": "paused", "type": "bool", "reverse": True},
+                {"name": "paused", "type": "bool", "default": False},
                 {
                     "name": "enabled",
                     "source": "disabled",

--- a/custom_components/mikrotik_router/switch.py
+++ b/custom_components/mikrotik_router/switch.py
@@ -380,7 +380,7 @@ class MikrotikKidcontrolPauseSwitch(MikrotikSwitch):
         path = self.entity_description.data_switch_path
         param = self.entity_description.data_reference
         value = self._data[self.entity_description.data_reference]
-        command = "resume"
+        command = "pause"
         self.coordinator.execute(path, command, param, value)
         await self.coordinator.async_refresh()
 
@@ -392,6 +392,6 @@ class MikrotikKidcontrolPauseSwitch(MikrotikSwitch):
         path = self.entity_description.data_switch_path
         param = self.entity_description.data_reference
         value = self._data[self.entity_description.data_reference]
-        command = "pause"
+        command = "resume"
         self.coordinator.execute(path, command, param, value)
         await self.coordinator.async_refresh()


### PR DESCRIPTION
## Proposed change
While setting up a simple Kidcontrol card, I noticed the Paused switch state is reversed from what one would expect. 

In routerOS:
- "Pause" button sets "P" flag (PAUSED) which triggers "B" flag (BLOCKED) and enforces rules regardless of schedule. 
- "Resume" button removes PAUSED flag (this clears BLOCKED if no other conditions are met).  

In HA/Integration, `MikrotikKidcontrolPauseSwitch` issues these commands via switch state, however they are reversed in the switch definition and coordinator

 ```
{"name": "paused", "type": "bool", "reverse": True},
```

Thusly, an element tracking the Paused state requires inverting at the card level: 
```yaml
        -entity: switch.mikrotik_kidcontrol_kid1_paused
          icon: |
            [[[ 
              if (entity.state == "on") return 'mdi:wifi';    // Access is not blocked but should be
              else return 'mdi:wifi-off';                     // Access is blocked but shouldn't be
            ]]]
```

With this change, toggling `paused` to ON will set the PAUSED state in RouterOS and accurately reflect the remote state. Toggling it OFF will clear the flag. 

## Type of change
<!--
  What type of change does your PR introduces?
-->
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
I inspected `git blame`, there doesn't seem to be a reason the switch is set this way. It's rather old code.

_This is a breaking change_, any automation or dashboards tracking the state of `paused` attribute will require reversing. 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [x] The code change is tested and works locally.
- [ ] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.
