### PR TITLE
Check firmware version even without write access

### DIFF
--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -1577,7 +1577,7 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
 
         full_version = resources["version"]
         try:
-            version_match = re.match(r"^(\d+)\.(\d+)\.(\d+)", full_version)
+            version_match = re.match(r"^(\d+)\.(\d+)", full_version)
             if not version_match:
                 raise ValueError("Version format is not recognized")
             version_major = int(version_match.group(1))


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here. If it fixes a bug
  or resolves a feature request, be sure to link to that issue.
-->
The current firmware version check requires `write`+`policy`+`reboot` access.
This prevents some features from working when only `read`+`api` access are granted (e.g. https://github.com/tomaae/homeassistant-mikrotik_router/issues/381).

This method appears to be compatible with both RouterOS 6 and 7 (according to the MikroTik documentation), but I have only tested it on RouterOS 7.

## Type of change
<!--
  What type of change does your PR introduces?
-->
- [ ] Bugfix
- [X] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->
- [X] The code change is tested and works locally.
- [X] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.

## Summary by Sourcery

Enable firmware version checks using only read and API access by introducing a read-only retrieval method and removing write-dependent parsing

New Features:
- Add get_firmware_version method to fetch and parse firmware version from the read-only system resource endpoint
- Invoke firmware version retrieval in get_firmware_update before requiring write permissions

Enhancements:
- Remove legacy version-parsing logic that depended on write access to the fw-update response