### PR TITLE
Fix wireless device detection and classification

### DIFF
--- a/custom_components/mikrotik_router/device_tracker.py
+++ b/custom_components/mikrotik_router/device_tracker.py
@@ -187,7 +187,21 @@ class MikrotikHostDeviceTracker(MikrotikDeviceTracker):
         if not self.option_track_network_hosts:
             return False
 
-        if self._data["source"] in ["capsman", "wireless"]:
+        # Check if device is connected to wireless interface
+        interface = self._data.get("interface", "").lower()
+        is_wireless_interface = (
+            interface.startswith("wlan") or
+            interface.startswith("wifi") or
+            self._data["source"] in ["capsman", "wireless"]
+        )
+
+        _LOGGER.debug(
+            "Device tracker %s: interface=%s, source=%s, is_wireless=%s, available=%s",
+            self.entity_id, interface, self._data["source"], is_wireless_interface,
+            self._data[self.entity_description.data_attribute]
+        )
+
+        if is_wireless_interface:
             return self._data[self.entity_description.data_attribute]
 
         return bool(
@@ -199,7 +213,15 @@ class MikrotikHostDeviceTracker(MikrotikDeviceTracker):
     @property
     def icon(self) -> str:
         """Return the icon."""
-        if self._data["source"] in ["capsman", "wireless"]:
+        # Check if device is connected to wireless interface
+        interface = self._data.get("interface", "").lower()
+        is_wireless_interface = (
+            interface.startswith("wlan") or
+            interface.startswith("wifi") or
+            self._data["source"] in ["capsman", "wireless"]
+        )
+
+        if is_wireless_interface:
             if self._data[self.entity_description.data_attribute]:
                 return self.entity_description.icon_enabled
             else:


### PR DESCRIPTION
## Description
Fixes wireless device detection and classification issues where devices were incorrectly counted as wired instead of wireless.

## Problem
- Issue #421: Integration not reporting number of wireless clients (always reporting 0)
- Devices connected to wireless interfaces were being classified as wired due to incorrect interface information

## Root Cause
- Interface update logic was nested inside address comparison conditions
- Bridge host data containing correct physical interface information was not being used
- DHCP/ARP data was overriding correct interface information with "bridge"

## Solution
- Always update interface from bridge host data for DHCP/ARP devices
- Add wireless interface detection based on interface names (wlan*, wifi*)
- Update device classification logic to properly count wired vs wireless devices
- Add debug logging for troubleshooting

## Changes
- `coordinator.py`: Fixed interface update logic and added wireless detection
- `device_tracker.py`: Updated connection source and icon logic for wireless devices

## Testing
Tested on:
- MikroTik RB951G-2HnD
- RouterOS 7.20 (stable)
- Architecture: mipsbe

- Verified correct classification of a few wired and wireless devices (was showing 7 wired)
- Debug logs show proper interface names and classification

Fixes #421

## Summary by Sourcery

Fix wireless device detection and classification by using bridge host interface data, detecting wireless interfaces by name, and improving debug logging.

New Features:
- Add wireless interface detection based on interface name patterns

Bug Fixes:
- Correct device classification to properly count wireless and wired clients
- Always update device interface from bridge host data for DHCP/ARP records

Enhancements:
- Add debug logging for wireless host retrieval, per-device classification, and final client counts