### PR TITLE
Fix config flow blocking connect, diagnostics tracker, update state

### DIFF
--- a/custom_components/mikrotik_router/config_flow.py
+++ b/custom_components/mikrotik_router/config_flow.py
@@ -119,7 +119,8 @@ class MikrotikControllerConfigFlow(ConfigFlow, domain=DOMAIN):
                 use_ssl=user_input[CONF_SSL],
                 ssl_verify=user_input[CONF_VERIFY_SSL],
             )
-            if not api.connect():
+            connected = await self.hass.async_add_executor_job(api.connect)
+            if not connected:
                 errors[CONF_HOST] = api.error
 
             # Save instance

--- a/custom_components/mikrotik_router/config_flow.py
+++ b/custom_components/mikrotik_router/config_flow.py
@@ -176,7 +176,7 @@ class MikrotikControllerOptionsFlowHandler(OptionsFlow):
 
     def __init__(self, config_entry):
         """Initialize options flow."""
-        self.config_entry = config_entry
+        self._config_entry = config_entry
         self.options = dict(config_entry.options)
 
     async def async_step_init(self, user_input=None):
@@ -196,25 +196,25 @@ class MikrotikControllerOptionsFlowHandler(OptionsFlow):
                 {
                     vol.Optional(
                         CONF_SCAN_INTERVAL,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
                         ),
                     ): int,
                     vol.Optional(
                         CONF_TRACK_IFACE_CLIENTS,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_TRACK_IFACE_CLIENTS, DEFAULT_TRACK_IFACE_CLIENTS
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_TRACK_HOSTS_TIMEOUT,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_TRACK_HOSTS_TIMEOUT, DEFAULT_TRACK_HOST_TIMEOUT
                         ),
                     ): int,
                     vol.Optional(
                         CONF_ZONE,
-                        default=self.config_entry.options.get(CONF_ZONE, STATE_HOME),
+                        default=self._config_entry.options.get(CONF_ZONE, STATE_HOME),
                     ): str,
                 }
             ),
@@ -232,86 +232,86 @@ class MikrotikControllerOptionsFlowHandler(OptionsFlow):
                 {
                     vol.Optional(
                         CONF_SENSOR_PORT_TRACKER,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_SENSOR_PORT_TRACKER, DEFAULT_SENSOR_PORT_TRACKER
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_SENSOR_PORT_TRAFFIC,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_SENSOR_PORT_TRAFFIC, DEFAULT_SENSOR_PORT_TRAFFIC
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_TRACK_HOSTS,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_TRACK_HOSTS, DEFAULT_TRACK_HOSTS
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_SENSOR_CLIENT_TRAFFIC,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_SENSOR_CLIENT_TRAFFIC, DEFAULT_SENSOR_CLIENT_TRAFFIC
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_SENSOR_CLIENT_CAPTIVE,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_SENSOR_CLIENT_CAPTIVE, DEFAULT_SENSOR_CLIENT_CAPTIVE
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_SENSOR_SIMPLE_QUEUES,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_SENSOR_SIMPLE_QUEUES, DEFAULT_SENSOR_SIMPLE_QUEUES
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_SENSOR_NAT,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_SENSOR_NAT, DEFAULT_SENSOR_NAT
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_SENSOR_MANGLE,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_SENSOR_MANGLE, DEFAULT_SENSOR_MANGLE
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_SENSOR_FILTER,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_SENSOR_FILTER, DEFAULT_SENSOR_FILTER
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_SENSOR_KIDCONTROL,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_SENSOR_KIDCONTROL, DEFAULT_SENSOR_KIDCONTROL
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_SENSOR_NETWATCH_TRACKER,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_SENSOR_NETWATCH_TRACKER,
                             DEFAULT_SENSOR_NETWATCH_TRACKER,
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_SENSOR_PPP,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_SENSOR_PPP, DEFAULT_SENSOR_PPP
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_SENSOR_SCRIPTS,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_SENSOR_SCRIPTS, DEFAULT_SENSOR_SCRIPTS
                         ),
                     ): bool,
                     vol.Optional(
                         CONF_SENSOR_ENVIRONMENT,
-                        default=self.config_entry.options.get(
+                        default=self._config_entry.options.get(
                             CONF_SENSOR_ENVIRONMENT, DEFAULT_SENSOR_ENVIRONMENT
                         ),
                     ): bool,

--- a/custom_components/mikrotik_router/const.py
+++ b/custom_components/mikrotik_router/const.py
@@ -86,6 +86,7 @@ TO_REDACT = {
     "to-addresses",
     "src-address",
     "dst-address",
+    "host",
     "username",
     "password",
     "caller-id",

--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -714,16 +714,16 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
 
         if not self.accessrights_reported:
             self.accessrights_reported = True
-            if (
-                "write" not in self.ds["access"]
-                or "policy" not in self.ds["access"]
-                or "reboot" not in self.ds["access"]
-                or "test" not in self.ds["access"]
-            ):
+            required_policies = {"api", "write", "policy", "reboot", "test"}
+            missing_policies = sorted(
+                policy for policy in required_policies if policy not in self.ds["access"]
+            )
+            if missing_policies:
                 _LOGGER.warning(
-                    "Mikrotik %s user %s does not have sufficient access rights. Integration functionality will be limited.",
+                    "Mikrotik %s user %s does not have sufficient access rights (missing: %s). Integration functionality will be limited.",
                     self.host,
                     self.config_entry.data[CONF_USERNAME],
+                    ",".join(missing_policies),
                 )
 
     # ---------------------------

--- a/custom_components/mikrotik_router/diagnostics.py
+++ b/custom_components/mikrotik_router/diagnostics.py
@@ -13,7 +13,7 @@ async def async_get_config_entry_diagnostics(
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     data_coordinator = hass.data[DOMAIN][config_entry.entry_id].data_coordinator
-    tracker_coordinator = hass.data[DOMAIN][config_entry.entry_id].data_coordinator
+    tracker_coordinator = hass.data[DOMAIN][config_entry.entry_id].tracker_coordinator
 
     return {
         "entry": {

--- a/custom_components/mikrotik_router/update.py
+++ b/custom_components/mikrotik_router/update.py
@@ -141,10 +141,7 @@ class MikrotikRouterBoardFWUpdate(MikrotikEntity, UpdateEntity):
     @property
     def is_on(self) -> bool:
         """Return true if device is on."""
-        return (
-            self.data["routerboard"]["current-firmware"]
-            != self.data["routerboard"]["upgrade-firmware"]
-        )
+        return self._data.get("current-firmware") != self._data.get("upgrade-firmware")
 
     @property
     def installed_version(self) -> str:


### PR DESCRIPTION
Fix three core issues affecting setup reliability and entity behavior:
- Avoid blocking Home Assistant’s event loop during config flow connection test (run connect in executor).
- Diagnostics: use the correct tracker coordinator.
- Fix RouterBOARD firmware update entity state handling.
- Fix options flow crash on HA 2025.12 when opening Configure (OptionsFlow config_entry setter).
- Improve access-rights warning to include RouterOS 'api' policy and list missing policies.

Files: config_flow.py, diagnostics.py, update.py, coordinator.py

Tested (HA, local):
- Configure (options) UI opens without 500 error on HA 2025.12.
- RouterBOARD firmware update entity reports up-to-date after upgrade.
- Using the entity’s Update action successfully triggered the RouterBOARD firmware update.
- Diagnostics download succeeds; coordinator mismatch no longer breaks tracker diagnostics.
- Diagnostics now redact configured host/IP ("host").
- Config flow remains responsive during validation.
- Wrong credentials / SSL misconfig fails and returns to form (no UI hang).
- With non-SSL + correct creds, setup continues and port/entity discovery completes (took ~15–20s for interface/port discovery in this environment).

## Summary by Sourcery

Improve Mikrotik router integration reliability, configuration responsiveness, and diagnostics safety in Home Assistant.

New Features:
- Include the RouterOS 'api' policy in access-rights checks and log which access policies are missing for the integration user.
- Redact the configured host/IP field from captured diagnostics data.

Bug Fixes:
- Run the config flow connection test in an executor to avoid blocking Home Assistant's event loop during setup validation.
- Fix the options flow handler to use the correct config entry attribute, preventing crashes when opening configuration on newer Home Assistant versions.
- Correct the RouterBOARD firmware update entity to derive its state from the current and upgrade firmware fields on the coordinator data.
- Use the tracker coordinator instead of the data coordinator when generating tracker diagnostics, ensuring diagnostics work correctly.