### PR TITLE
Fix config defaults and TLS hostname verification behavior

### DIFF
--- a/custom_components/mikrotik_router/config_flow.py
+++ b/custom_components/mikrotik_router/config_flow.py
@@ -135,7 +135,7 @@ class MikrotikControllerConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_NAME: DEFAULT_DEVICE_NAME,
                 CONF_HOST: DEFAULT_HOST,
                 CONF_USERNAME: DEFAULT_USERNAME,
-                CONF_PASSWORD: DEFAULT_USERNAME,
+                CONF_PASSWORD: "",
                 CONF_PORT: DEFAULT_PORT,
                 CONF_SSL: DEFAULT_SSL,
                 CONF_VERIFY_SSL: DEFAULT_VERIFY_SSL,

--- a/custom_components/mikrotik_router/mikrotikapi.py
+++ b/custom_components/mikrotik_router/mikrotikapi.py
@@ -127,11 +127,18 @@ class MikrotikAPI:
             if self._use_ssl:
                 if self._ssl_wrapper is None:
                     ssl_context = ssl.create_default_context()
+
                     # For IP-based connections, hostname checks generally don't work with
                     # MikroTik's default/self-signed certs. If the user connects via a
                     # hostname and enables verification, do enforce hostname validation.
+                    host_for_ip_check = str(self._host).strip()
+                    if host_for_ip_check.startswith("[") and "]" in host_for_ip_check:
+                        host_for_ip_check = host_for_ip_check.split("]", 1)[0][1:]
+                    elif ":" in host_for_ip_check and host_for_ip_check.count(":") == 1:
+                        host_for_ip_check = host_for_ip_check.rsplit(":", 1)[0]
+
                     try:
-                        ipaddress.ip_address(self._host)
+                        ipaddress.ip_address(host_for_ip_check)
                         is_ip_address = True
                     except ValueError:
                         is_ip_address = False


### PR DESCRIPTION
Improve setup defaults and SSL behavior:
- Config flow: default password no longer mirrors username (defaults to blank).
- TLS: only enable hostname verification when verify_ssl is enabled AND the host is a DNS name (keeps common IP-based LAN cert setups working).

Files: config_flow.py, mikrotikapi.py

Test notes:
- If RouterOS api-ssl has certificate=none (no server cert), SSL connections fail during handshake; use non-SSL or configure a cert for api-ssl.

Tested (HA, local):
- With non-SSL + correct creds, setup continues and port discovery completes (took ~15–20s), then prompts for port rooms/locations.
- Config flow defaults: password blank; username admin; name Mikrotik; host 10.0.0.1; port 0; SSL/Verify SSL unchecked.

## Summary by Sourcery

Adjust configuration defaults and TLS hostname verification behavior for MikroTik router integration.

Bug Fixes:
- Ensure TLS hostname verification is only enforced when SSL verification is enabled and the target is a hostname rather than an IP address.

Enhancements:
- Update the config flow so the default password field is blank instead of mirroring the default username.