### PR TITLE
Stabilize entity unique_id generation (backwards compatible)

### DIFF
--- a/custom_components/mikrotik_router/entity.py
+++ b/custom_components/mikrotik_router/entity.py
@@ -81,7 +81,8 @@ def _select_unique_id(
     entity_registry = er.async_get(hass)
 
     stable_uid = _stable_unique_id(config_entry.entry_id, entity_description, uid)
-    legacy_uid = _legacy_unique_id(config_entry.data[CONF_NAME], entity_description, data)
+    legacy_name = config_entry.data.get(CONF_NAME) or config_entry.title
+    legacy_uid = _legacy_unique_id(legacy_name, entity_description, data)
 
     if entity_registry.async_get_entity_id(platform_domain, DOMAIN, stable_uid):
         return stable_uid
@@ -251,7 +252,7 @@ class MikrotikEntity(CoordinatorEntity[_MikrotikCoordinatorT], Entity):
 
         # Provide a stable default if the platform didn't override _attr_unique_id.
         # We intentionally do not use the config entry name here.
-        if not getattr(self, "_attr_unique_id", None):
+        if getattr(self, "_attr_unique_id", None) is None:
             self._attr_unique_id = _stable_unique_id(
                 self._config_entry.entry_id, self.entity_description, self._uid
             )


### PR DESCRIPTION
Stabilize Home Assistant entity unique_ids while avoiding upgrade churn:\n- New entities: stable unique_id based on config_entry.entry_id (rename-safe).\n- Existing installs: keep legacy unique_ids if already present in the entity registry (prevents duplicate entities on upgrade).\n\nFiles: entity.py, device_tracker.py

Tested (HA, local):
- Renamed the config entry (Mikrotik -> Home Mikrotik) and reloaded; device/entity counts remained 26/38 and no duplicates appeared.
- Baseline: 26 devices, 38 entities.
- Renamed a port entity from Mikrotik Ether1 -> Mikrotik Test Ether1; after reload (~15–20s) counts remained 26 devices / 38 entities and no duplicate Ether1 entity appeared.

## Summary by Sourcery

Stabilize and future-proof unique_id generation for Mikrotik router entities while preserving backwards compatibility with existing Home Assistant entity registry entries.

Bug Fixes:
- Prevent duplicate entities from being created when config entry names change by decoupling unique_ids from the entry name.

Enhancements:
- Introduce helper functions to generate stable, config-entry-based unique_ids and preserve legacy formats when already registered.
- Refine entity creation logic to choose between stable and legacy unique_ids based on existing registry entries, preventing duplicates during config entry renames or upgrades.
- Default Mikrotik entities to a stable unique_id when none is explicitly set by the platform.