### PR TITLE
Fix interface device naming in DeviceInfo

### DIFF
--- a/custom_components/mikrotik_router/entity.py
+++ b/custom_components/mikrotik_router/entity.py
@@ -287,9 +287,9 @@ class MikrotikEntity(CoordinatorEntity[_MikrotikCoordinatorT], Entity):
         else:
             return DeviceInfo(
                 connections={(dev_connection, f"{dev_connection_value}")},
-                default_name=f"{self._inst} {dev_group}",
-                default_model=f"{self.coordinator.data['resource']['board-name']}",
-                default_manufacturer=f"{self.coordinator.data['resource']['platform']}",
+                name=f"{self._inst} {dev_group}",
+                model=f"{self.coordinator.data['resource']['board-name']}",
+                manufacturer=f"{self.coordinator.data['resource']['platform']}",
                 via_device=(
                     DOMAIN,
                     f"{self.coordinator.data['routerboard']['serial-number']}",


### PR DESCRIPTION
## Proposed change
Fix interface device naming bug where a network interface entity inherited the 'MikroTik Router' name instead of its correct interface name

Ref: tomaae/homeassistant-mikrotik_router#386

## Type of change
- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements
- [ ] Documentation

## Additional information
AI-generated fix. Development involved iterative debugging with Copilot to identify that DeviceInfo behavior, not API parsing, was the root cause.

## Checklist
- [x] The code change is tested and works locally.
- [x] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [x] Documentation added/updated if required.

## Summary by Sourcery

Bug Fixes:
- Fix network interface entities incorrectly inheriting the generic router name by using the proper DeviceInfo fields for name, model, and manufacturer.