### PR TITLE
fix: librouteros 4.0.0 compatibility (login_method and plain callable)

### DIFF
--- a/custom_components/mikrotik_router/const.py
+++ b/custom_components/mikrotik_router/const.py
@@ -16,7 +16,8 @@ DEFAULT_NAME = "Mikrotik Router"
 ATTRIBUTION = "Data provided by Mikrotik"
 
 DEFAULT_ENCODING = "ISO-8859-1"
-DEFAULT_LOGIN_METHOD = "plain"
+from librouteros.login import plain
+DEFAULT_LOGIN_METHOD = plain
 
 DEFAULT_HOST = "10.0.0.1"
 DEFAULT_USERNAME = "admin"

--- a/custom_components/mikrotik_router/mikrotikapi.py
+++ b/custom_components/mikrotik_router/mikrotikapi.py
@@ -117,7 +117,7 @@ class MikrotikAPI:
 
         kwargs = {
             "encoding": self._encoding,
-            "login_methods": self._login_method,
+            "login_method": self._login_method,
             "port": self._port,
         }
 


### PR DESCRIPTION
## Proposed change

Fixes integration breakage on HA 2026.3+ caused by librouteros 4.0.0 
breaking changes.

Two fixes:

1. `const.py` - `DEFAULT_LOGIN_METHOD` was set to the string `"plain"` 
which librouteros 4.0.0 no longer accepts. It now requires a callable. 
Fixed by importing `plain` from `librouteros.login` and assigning that 
instead.

2. `mikrotikapi.py` - `login_methods` (plural) renamed to `login_method` 
(singular) to match the librouteros API.

The root cause is librouteros 4.0.0 ([commit 40d9dd9](https://github.com/luqasz/librouteros/commit/40d9dd989f78d75a54d55d5d971d590584c29b9d)) 
which tightened argument validation. HA 2026.3 moved to Python 3.14 
which triggered fresh dependency resolution pulling in librouteros 4.0.1.

## Type of change

- [x] Bugfix

## Additional information

Tested and confirmed working on HA 2026.4.x with librouteros 4.0.1 
across two routers running RouterOS 7.21.3 and 7.22.1.

## Checklist

- [x] The code change is tested and works locally.
- [ ] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.

## Summary by Sourcery

Update Mikrotik router integration to restore compatibility with librouteros 4.x login API.

Bug Fixes:
- Use the librouteros `plain` login callable instead of the deprecated string value for the default login method.
- Rename the connection argument from `login_methods` to `login_method` to match the updated librouteros API.