### PR TITLE
Fix mikrotik python314

### DIFF
--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -707,10 +707,13 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
             ],
         )
 
-        if tmp_user[self.config_entry.data[CONF_USERNAME]]["group"] in tmp_group:
-            self.ds["access"] = tmp_group[
-                tmp_user[self.config_entry.data[CONF_USERNAME]]["group"]
-            ]["policy"].split(",")
+        #if tmp_user[self.config_entry.data[CONF_USERNAME]]["group"] in tmp_group:
+        current_user = self.config_entry.data.get(CONF_USERNAME)
+        if current_user in tmp_user:
+            if tmp_user[current_user]["group"] in tmp_group:
+                self.ds["access"] = tmp_group[
+                    tmp_user[self.config_entry.data[CONF_USERNAME]]["group"]
+                ]["policy"].split(",")
 
         if not self.accessrights_reported:
             self.accessrights_reported = True

--- a/custom_components/mikrotik_router/mikrotikapi.py
+++ b/custom_components/mikrotik_router/mikrotikapi.py
@@ -106,7 +106,7 @@ class MikrotikAPI:
         self._connection = None
         self._connection_epoch = 0
 
-    # ---------------------------
+ # ---------------------------
     #   connect
     # ---------------------------
     def connect(self) -> bool:
@@ -117,9 +117,18 @@ class MikrotikAPI:
 
         kwargs = {
             "encoding": self._encoding,
-            "login_methods": self._login_method,
             "port": self._port,
         }
+
+        if isinstance(self._login_method, str):
+            if self._login_method == "plain":
+                from librouteros.login import plain
+                kwargs["login_method"] = plain
+            elif self._login_method == "token":
+                from librouteros.login import token
+                kwargs["login_method"] = token
+        else:
+            kwargs["login_method"] = self._login_method
 
         self.lock.acquire()
         try:
@@ -134,6 +143,7 @@ class MikrotikAPI:
                         ssl_context.verify_mode = ssl.CERT_NONE
                     self._ssl_wrapper = ssl_context.wrap_socket
                 kwargs["ssl_wrapper"] = self._ssl_wrapper
+            
             self._connection = librouteros.connect(
                 self._host, self._username, self._password, **kwargs
             )


### PR DESCRIPTION
## Proposed change
This PR fixes a critical connection failure and subsequent integration crash occurring in Home Assistant 2026.4.2 (running Python 3.14) and RouterOS 7.22.1.

Fixes Connection Error: Updates mikrotikapi.py to handle the librouteros requirement for a callable login method instead of a string, resolving the 'str' object is not callable and unexpected keyword argument 'login_methods' errors.

Fixes Coordinator Crash: Adds a safety check in coordinator.py to prevent a KeyError when a configured username is not immediately found in the user list returned by the Mikrotik API.

Fixes https://github.com/tomaae/homeassistant-mikrotik_router/issues/477
and possibly Fixes https://github.com/tomaae/homeassistant-mikrotik_router/issues/481

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information
The transition to Python 3.14 strictly enforces argument naming and callable types in the underlying librouteros library. Additionally, recent RouterOS firmware updates have altered the timing or structure of user group data returned via API, necessitating more robust dictionary lookups in the coordinator to prevent the integration from failing during the update cycle.

## Checklist
- [x] The code change is tested and works locally.
- [ ] The code has been formatted using Black.
- [ ] Tests have been added to verify that the new code works.
- [ ] Documentation added/updated if required.

## Summary by Sourcery

Fix Mikrotik router integration connection and access handling for newer Python/librouteros and RouterOS versions.

Bug Fixes:
- Update Mikrotik API connection setup to pass a callable login method instead of a string to librouteros, restoring connectivity on newer Python/librouteros versions.
- Guard access-rights lookup in the coordinator by checking the configured user exists before reading its group, preventing KeyError crashes when the user is missing from the Mikrotik API response.