### PR TITLE
Fix mangle switch uniq-id lookup and set_value .id fast-path

### DIFF
--- a/custom_components/mikrotik_router/coordinator.py
+++ b/custom_components/mikrotik_router/coordinator.py
@@ -1094,6 +1094,8 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                 {"name": "dst-port", "default": "any"},
                 {"name": "src-address-list", "default": "any"},
                 {"name": "dst-address-list", "default": "any"},
+                {"name": "new-routing-mark", "default": ""},
+                {"name": "src-mac-address", "default": ""},
                 {
                     "name": "enabled",
                     "source": "disabled",
@@ -1122,6 +1124,12 @@ class MikrotikCoordinator(DataUpdateCoordinator[None]):
                     {"key": "src-address-list"},
                     {"text": "-"},
                     {"key": "dst-address-list"},
+                    {"text": ","},
+                    {"key": "comment"},
+                    {"text": ","},
+                    {"key": "new-routing-mark"},
+                    {"text": ","},
+                    {"key": "src-mac-address"},
                 ],
                 [
                     {"name": "name"},

--- a/custom_components/mikrotik_router/mikrotikapi.py
+++ b/custom_components/mikrotik_router/mikrotikapi.py
@@ -351,39 +351,47 @@ class MikrotikAPI:
     # ---------------------------
     def set_value(self, path, param, value, mod_param, mod_value) -> bool:
         """Modify a parameter"""
-        entry_found = None
-
         if not self.connection_check():
             return False
 
-        response = self.query(path, return_list=False)
-        if response is None:
+        self.lock.acquire()
+        try:
+            response = self._connection.path(path)
+        except Exception as e:
+            self.disconnect("set_value path", e)
+            self.lock.release()
             return False
 
-        for tmp in response:
-            if param not in tmp:
-                continue
+        if param == ".id":
+            entry_found = value
+        else:
+            try:
+                for tmp in response:
+                    if param not in tmp:
+                        continue
+                    if tmp[param] != value:
+                        continue
+                    entry_found = tmp[".id"]
+            except Exception as e:
+                self.disconnect("set_value search", e)
+                self.lock.release()
+                return False
 
-            if tmp[param] != value:
-                continue
-
-            entry_found = tmp[".id"]
-
-        if not entry_found:
-            _LOGGER.error(
-                "Mikrotik %s set_value parameter %s with value %s not found",
-                self._host,
-                param,
-                value,
-            )
-            return True
+            if not entry_found:
+                _LOGGER.error(
+                    "Mikrotik %s set_value parameter %s with value %s not found",
+                    self._host,
+                    param,
+                    value,
+                )
+                self.lock.release()
+                return True
 
         params = {".id": entry_found, mod_param: mod_value}
-        self.lock.acquire()
         try:
             response.update(**params)
         except Exception as e:
-            self.disconnect("set_value", e)
+            self.disconnect("set_value update", e)
             self.lock.release()
             return False
 

--- a/custom_components/mikrotik_router/switch.py
+++ b/custom_components/mikrotik_router/switch.py
@@ -246,12 +246,7 @@ class MikrotikMangleSwitch(MikrotikSwitch):
         param = ".id"
         value = None
         for uid in self.coordinator.data["mangle"]:
-            if self.coordinator.data["mangle"][uid]["uniq-id"] == (
-                f"{self._data['chain']},{self._data['action']},{self._data['protocol']},"
-                f"{self._data['src-address']}:{self._data['src-port']}-"
-                f"{self._data['dst-address']}:{self._data['dst-port']},"
-                f"{self._data['src-address-list']}-{self._data['dst-address-list']}"
-            ):
+            if self.coordinator.data["mangle"][uid]["uniq-id"] == self._data["uniq-id"]:
                 value = self.coordinator.data["mangle"][uid][".id"]
 
         mod_param = self.entity_description.data_switch_parameter
@@ -267,12 +262,7 @@ class MikrotikMangleSwitch(MikrotikSwitch):
         param = ".id"
         value = None
         for uid in self.coordinator.data["mangle"]:
-            if self.coordinator.data["mangle"][uid]["uniq-id"] == (
-                f"{self._data['chain']},{self._data['action']},{self._data['protocol']},"
-                f"{self._data['src-address']}:{self._data['src-port']}-"
-                f"{self._data['dst-address']}:{self._data['dst-port']},"
-                f"{self._data['src-address-list']}-{self._data['dst-address-list']}"
-            ):
+            if self.coordinator.data["mangle"][uid]["uniq-id"] == self._data["uniq-id"]:
                 value = self.coordinator.data["mangle"][uid][".id"]
 
         mod_param = self.entity_description.data_switch_parameter

--- a/custom_components/mikrotik_router/switch_types.py
+++ b/custom_components/mikrotik_router/switch_types.py
@@ -101,6 +101,8 @@ DEVICE_ATTRIBUTES_MANGLE = [
     "dst-address",
     "dst-port",
     "comment",
+    "new-routing-mark",
+    "src-mac-address",
 ]
 
 DEVICE_ATTRIBUTES_FILTER = [


### PR DESCRIPTION
Fixes a bug where mangle switch lookups always failed, so turning mangle switches on/off had no effect on the router.

### Problem
`MikrotikMangleSwitch.async_turn_on/off()` reconstructed the `uniq-id` string manually but omitted `comment`, `new-routing-mark`, and `src-mac-address`. The lookup never matched, so `value` stayed `None` and `set_value()` logged "not found" without changing anything.

### Fix
- **coordinator.py**: include `comment`/`new-routing-mark`/`src-mac-address` in the mangle `uniq-id` computation so rules differing only by those fields get unique keys
- **switch.py**: use the cached `uniq-id` from coordinator data instead of reconstructing a partial key
- **mikrotikapi.py**: `.id` fast-path in `set_value()` — when `param == ".id"`, use the value directly instead of re-querying the router, eliminating the race window between lock release and path iteration

## Summary by Sourcery

Fix mangle rule identification and reliably apply switch state changes to matching router rules.

Bug Fixes:
- Fix mangle switch lookups so turning rules on or off correctly updates the matching router rule.
- Prevent `.id` updates from failing due to an unnecessary router re-query and race window.

Enhancements:
- Expand mangle rule identifiers to distinguish rules by comment, routing mark, and source MAC address.